### PR TITLE
add a little that is shown when the user clicks on the account button…

### DIFF
--- a/src/app/layout/desktop-menu/desktop-menu.component.html
+++ b/src/app/layout/desktop-menu/desktop-menu.component.html
@@ -24,11 +24,21 @@
       </div>
     </div>
     <div class="user-options">
-      <button mat-icon-button>
+      <button mat-icon-button [matMenuTriggerFor]="menu">
         <mat-icon class="icon-display">
           account_circle
         </mat-icon>
       </button>
+      <mat-menu #menu="matMenu">
+        <button mat-menu-item>
+          <mat-icon>login</mat-icon>
+          <span>Entrar</span>
+        </button>
+        <button mat-menu-item [routerLink]="['/cadastro-cliente']">
+          <mat-icon>person_add</mat-icon>
+          <span>Criar conta</span>
+        </button>
+      </mat-menu>
       <button
         mat-icon-button
         class="flex-button"

--- a/src/app/layout/layout.module.ts
+++ b/src/app/layout/layout.module.ts
@@ -13,6 +13,7 @@ import { MatCardModule } from '@angular/material/card';
 import { RouterModule } from '@angular/router';
 import { PedidoModule } from '../pedido/pedido.module';
 import { MatBadgeModule } from '@angular/material/badge';
+import { MatMenuModule } from '@angular/material/menu';
 
 @NgModule({
   declarations: [
@@ -31,7 +32,8 @@ import { MatBadgeModule } from '@angular/material/badge';
     RouterModule,
     PedidoModule,
     MatCardModule,
-    MatBadgeModule
+    MatBadgeModule,
+    MatMenuModule
   ],
   exports: [
     MenuComponent,


### PR DESCRIPTION
# TASK - Abrir um pequeno menu ao clicar no ícone "account" (desktop breakpoint)
## O que foi feito?

* Eu adicionei um mat-menu ao componente de menu desktop para que, quando o usuário clique no ícone _account_, um pequeno menu seja aberto.

## Como testar?

1. Estando na tela de produtos (lado do cliente), clique no ícone _account_.
2. Em seguinda, um pequeno menu deverá ser aberto.
3. Verifique se as opções disponíveis dentro do menu são "entrar" (usuário já possui conta) e "criar conta" (usuário ainda não possui conta e irá realizar o cadastro).
